### PR TITLE
add gh deploy method for travis

### DIFF
--- a/.build_scripts/deploy.sh
+++ b/.build_scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e # halt script on error
+
+echo "Get ready, we're pushing to gh-pages!"
+cd _site
+git init
+git config user.name "Travis-CI"
+git config user.email "travis@somewhere.com"
+git add .
+git commit -m "CI deploy to gh-pages"
+git push --force --quiet "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" master:gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 - chmod +x ./.build_scripts/deploy.sh
 
 script:
-- npm run build
+- gulp
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: node_js
 
 node_js:
-  - '4'
+- '4'
 
 env:
   global:
   - CXX=g++-4.8
-  - DEPLOY_BRANCH=develop
+  - DEPLOY_BRANCH=master
+  - secure: "JAE59oZX9t5NSo5P3EwEJ6kxh/1gAYouozZ2vOU8CB4AWWum2UU53jniB3P+cos8uvui9MxeY80D+UP7mhlUtz0JrxHfRiQXbqNnFJxBg929KFfMhhH5fiNypC7fyc0Wwj5Arw+C+D6nqjQtEgdJnTh3YwxACn9fPhIibV6mYUWGyrUvageLG2LIQxNnkz05YlRnJx32Oq8ft3H5AQ4ZN81R3lWSQ3zI8zFyMfmm63fTN3r6tOSVpYsZRgVvb5MEpp4C+pYT2VA5vdLhAXwRNhDZkPSxRo3SIax4q+38qpz6A919kgfW9mcDsz81s850vfRrENv7EepN2ZgpEZtkVliyidxt5ACc41+0YN3HZQyp1fYUeRotmN3eS1Y2wzfYOVZgB4pdfZtTIG1Zb8qW5GmiLQKIpG5LBB7dWgs0C6DtN3mu/+qFAfdiUjr2I9tuCSHPVE/xW0tdP6Vr1lzD/hYEDhit/HnlO4d2y3Dh8Pplm/z0MFt6H8GFph5/rqr/+X/dDHbS0js2vzq+AX+6FqM/XTD9HVl+/8wliBPoXHWRy3FXF1vOT80XxTO/ho0iz2yl21yAU3MuumsEhUcwiWFwpVxTtkzDxXMXrMJzHGK1VDbNe7oxWtmk+2BTSOnw/Ps6kiygPTLEtHEjQL/4iZdlIEt0NrjstUCm4ifrWog="
 
 addons:
   apt:
@@ -20,18 +21,15 @@ cache:
   directories:
   - node_modules
 
+before_install:
+- chmod +x ./.build_scripts/deploy.sh
+
 script:
-  - gulp prod
+- npm run build
 
 deploy:
-  provider: s3
-  access_key_id: $AWS_ACCESS_KEY
-  secret_access_key: $AWS_SECRET_KEY
-  bucket: ds-mm-partner
+  provider: script
   skip_cleanup: true
-  region: us-east-1
-  local_dir: _site
-  acl: public_read
+  script: ".build_scripts/deploy.sh"
   on:
-    repo: MissingMaps/partners
     branch: "${DEPLOY_BRANCH}"


### PR DESCRIPTION
Switches default deploy method from S3 to Github Pages. This is to prep for go live on mm.org.