### PR TITLE
missingmaps.org doesn't have a valid SSL cert

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -285,7 +285,7 @@ function setupGraphs () {
 
 // Returns svg link to Missing Maps user endpoint
 function generateUserUrl (userName) {
-  const userUrl = 'https://www.missingmaps.org/users/#/' + userName.replace(/\s+/g, '-').toLowerCase();
+  const userUrl = 'http://www.missingmaps.org/users/#/' + userName.replace(/\s+/g, '-').toLowerCase();
   return `<a xlink:href="${userUrl}" target="_blank" style="text-decoration:none">${userName}</a>`;
 }
 


### PR DESCRIPTION
Switch the protocol to http when linking to the user page.