### PR TITLE
increase limit of projects visible

### DIFF
--- a/app/_includes/projects.html
+++ b/app/_includes/projects.html
@@ -3,7 +3,7 @@
   <div class = "Projects-Container-Leftside">
     <div class = "flexslider Projects-slider">
       <ul class = "slides project-slide">
-        {% for p in page.tm-projects limit:10 %}
+        {% for p in page.tm-projects limit:15 %}
         <li id = Project-{{ p.id }}>
           <div class = "HOT-Container">
             <div class = "HOT-Map">


### PR DESCRIPTION
This increases the number of projects able to be seen on a project page. Tested and works for large and small projects. Salesforce now has 10+ projects. 

![salesforce 2018-03-13 18-07-59](https://user-images.githubusercontent.com/796838/37360911-74b023b8-26e9-11e8-8c9f-360082710f7b.png)

cc @RebeccaFirthy 