### PR TITLE
add salesforce-emea parnter page

### DIFF
--- a/app/_partner/salesforce-emea.md
+++ b/app/_partner/salesforce-emea.md
@@ -1,0 +1,32 @@
+---
+layout: partner
+lang: en
+permalink: /salesforce-emea/
+
+id: salesforceemea
+name: salesforceemea
+logo: Salesforce.svg
+contact: ahigginbottom@salesforce.com
+
+flickr: https://www.flickr.com/photos/140736557@N04/sets/72157697914137314/
+twitter: https://www.twitter.com/SalesforceOrg
+facebook:
+hoursname:
+hourslink:
+
+flickr-apikey: b4f0178b524610373b2b65bda51979ba
+flickr-setId: 72157666872027428
+
+primary-hashtag: salesforceemea
+subhashtags:
+  - salesforcefrance
+  - sfcpc
+  - sfcpcparis
+  - sfcpcnantes
+  - sfcpclyon
+  - sfcpcgrenoble
+
+tm-projects:
+  - id: 5170
+    desc: "Monsoon rains have caused severe flooding in the Kerala Region of India. Your help is needed to map affect areas so aid agencies and local responders can better assist in the recovery. HOT has received request of local expert mappers and people doing online coordinated mapping, as well as many people who want to contribute map data asking how to improve and add to OSM data."
+---


### PR DESCRIPTION
Adds the SalesforceEMEA page. Stats are not working at the moment since no edits have been made with the primary hashtag `salesforceemea`. 

@RebeccaFirthy Can you give this a quick once over and give a thumbs up if looks good? 

<img width="1292" alt="salesforce emea 2018-11-19 17-44-30" src="https://user-images.githubusercontent.com/796838/48725199-52163e00-ec23-11e8-93cf-557574bce6dd.png">
