### PR TITLE
add rounding for total edits chart

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -352,12 +352,12 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
       const totalSum = hashtags.reduce(function (acc, ht) {
         const vals = hashtagData[ht];
         if (!$.isEmptyObject(vals)) {
-          const sum = vals.building_count_add +
+          const sum = Math.round(vals.building_count_add +
                       vals.building_count_mod +
                       vals.road_km_add +
                       vals.road_km_mod +
                       vals.waterway_count_add +
-                      vals.poi_count_add;
+                      vals.poi_count_add);
           acc.push({name: ht, decorate: generateHashtagUrl, value: sum});
         }
         return acc;
@@ -614,12 +614,12 @@ function getGroupActivityStatsSubHashtag (hashtags, primaryHashtag) {
       const totalSum = hashtags.reduce(function (acc, ht) {
         const vals = hashtagData[ht];
         if (!$.isEmptyObject(vals)) {
-          const sum = vals.building_count_add +
+          const sum = Math.round(vals.building_count_add +
                       vals.building_count_mod +
                       vals.road_km_add +
                       vals.road_km_mod +
                       vals.waterway_count_add +
-                      vals.poi_count_add;
+                      vals.poi_count_add);
           acc.push({name: ht, decorate: generateHashtagUrl, value: sum});
         }
         return acc;


### PR DESCRIPTION
Total edits chart was showing decimals which differed from the Total Buildings and Total KM of Road charts. This PR adds rounding to the total edits to reduce the number of decimals shown. 

<img width="814" alt="salesforce 2018-11-19 18-19-16" src="https://user-images.githubusercontent.com/796838/48726591-c2bf5980-ec27-11e8-9c36-46a9e5b389db.png">
