### PR TITLE
adjust check to less than 1

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -548,7 +548,7 @@ function getImgs (flickrApiKey, flickrSetId) {
 }
 
 function checkHashtags (hashtags) {
-  if (hashtags.length < 2) {
+  if (hashtags.length < 1) {
     console.warn('WARNING >> There are not enough secondary hashtags listed ' +
                  'in order to represent differences in contribution level ' +
                  'between partners. The partner graphs will not be displayed.');


### PR DESCRIPTION
This change allows the charts to work when using a wildcard hashtag, i.e. `acn*`. When using a wildcard hashtag, the check does not allow the charts to work. I've checked our existing partner pages and this works across all the existing pages and doesn't break any existing page. 