### PR TITLE
Add resource links

### DIFF
--- a/app/_includes/projects.html
+++ b/app/_includes/projects.html
@@ -33,14 +33,14 @@
     <div class = "HOT-Nav">
       <div class = "HOT-Nav-Projects"></div>
     </div>
+    {% if page.links %}
     <div class = "Partnership-Resources">
-      {% if page.links %}
       <h3> Resources </h3>
       {% for l in page.links limit:3 %}
         <a href="{{ l.link }}" class="btn btn-blue">{{ l.title }}</a>
       {% endfor %}
-      {% endif %}
     </div>
+    {% endif %}
   </div>
   <div class = "GetInvolved">
 

--- a/app/_includes/projects.html
+++ b/app/_includes/projects.html
@@ -33,18 +33,28 @@
     <div class = "HOT-Nav">
       <div class = "HOT-Nav-Projects"></div>
     </div>
+    <div class = "Partnership-Resources">
+      {% if page.links %}
+      <h3> Resources </h3>
+      {% for l in page.links limit:3 %}
+        <a href="{{ l.link }}" class="btn btn-blue">{{ l.title }}</a>
+      {% endfor %}
+      {% endif %}
+    </div>
   </div>
   <div class = "GetInvolved">
-      {% if page.hourslink == null %}
-        <p>Support Missing Maps</p>
-        <p class='benevity-link'><a href="http://donate.hotosm.org/" class="btn btn-blue">DONATE </a></p>
-      {% else %}
-        <p>Log your hours</p>
-        <p class='benevity-link'><a href="{{ page.hourslink }}" class="btn btn-blue">{{ page.hoursname }} </a></p>
-      {% endif %}
 
-      <h3>New to Mapping?</h3>
-      <img src = "{{ site.domain }}{{ site.path_prefix }}/assets/graphics/content/process/Learn-MapNow.svg" width = "120"></img>
-      <p><a href="http://www.missingmaps.org/learn/" class="btn btn-blue">LEARN TO MAP </a></p>
+    
+    {% if page.hourslink == null %}
+      <p>Support Missing Maps</p>
+      <p class='benevity-link'><a href="http://donate.hotosm.org/" class="btn btn-blue">DONATE </a></p>
+    {% else %}
+      <p>Log your hours</p>
+      <p class='benevity-link'><a href="{{ page.hourslink }}" class="btn btn-blue">{{ page.hoursname }} </a></p>
+    {% endif %}
+
+    <h3>New to Mapping?</h3>
+    <img src = "{{ site.domain }}{{ site.path_prefix }}/assets/graphics/content/process/Learn-MapNow.svg" width = "120"></img>
+    <p><a href="http://www.missingmaps.org/learn/" class="btn btn-blue">LEARN TO MAP </a></p>
   </div>
 </div>

--- a/app/_partner/mmc.md
+++ b/app/_partner/mmc.md
@@ -18,7 +18,7 @@ links:
   - title: Register your Mapathon
     link: https://www.surveymonkey.com/r/MMCmapping
   - title: Intro Presentation
-    link: http://cdn.hotosm.org/MMC+Mapathon+Introduction+Presentation.pptx
+    link: http://cdn.hotosm.org/MMC+Mapathon+Introduction+Presentation_1.0.pptx
   - title: Trainer Presentation
     link: 
 

--- a/app/_partner/mmc.md
+++ b/app/_partner/mmc.md
@@ -14,6 +14,14 @@ facebook:
 hoursname:
 hourslink:
 
+links:
+  - title: Register your Mapathon
+    link: https://www.surveymonkey.com/r/MMCmapping
+  - title: Intro Presentation
+    link: http://cdn.hotosm.org/MMC+Mapathon+Introduction+Presentation.pptx
+  - title: Trainer Presentation
+    link: 
+
 flickr-apikey: b4f0178b524610373b2b65bda51979ba
 flickr-setId: 72157676557584408
 

--- a/app/_partner/mmc.md
+++ b/app/_partner/mmc.md
@@ -19,8 +19,6 @@ links:
     link: https://www.surveymonkey.com/r/MMCmapping
   - title: Intro Presentation
     link: http://cdn.hotosm.org/MMC+Mapathon+Introduction+Presentation_1.0.pptx
-  - title: Trainer Presentation
-    link: 
 
 flickr-apikey: b4f0178b524610373b2b65bda51979ba
 flickr-setId: 72157676557584408

--- a/app/assets/styles/_partnerpage.scss
+++ b/app/assets/styles/_partnerpage.scss
@@ -452,6 +452,10 @@ h1 {
   border-bottom: 1px solid #dbdbda;
 }
 
+.Partnership-Resources {
+  padding: 10px 0 8px 0;
+}
+
 /*----------------------------------------------*/
 /* EVENTS */
 /*----------------------------------------------*/


### PR DESCRIPTION
Adds a new section to the partner pages with links to partner resources. 

![image](https://user-images.githubusercontent.com/1847818/51750038-ec10c180-207e-11e9-9208-29fc1a6df6d6.png)

In the Partner page metadata, you can add up to 3 links as such:
```yaml
links:
  - title: Register your Mapathon
    link: https://www.surveymonkey.com/r/MMCmapping
  - title: Intro Presentation
    link: http://cdn.hotosm.org/MMC+Mapathon+Introduction+Presentation.pptx
  - title: Trainer Presentation
    link: 
```

I marked this WIP because I'm still waiting on one link url from Rebecca, but the design layout is ready for review. 