### PR TITLE
Add scroll bar to teams stats graphs

### DIFF
--- a/app/_includes/teams.html
+++ b/app/_includes/teams.html
@@ -28,7 +28,5 @@
       <div class="Team-User-Graph" id="Team-User-Roads-Graph"></div>
     </div>
   </div>
-  <div class="teams-more">
-    <div class="btn invert-btn-grn teams-btn">SHOW MORE TEAMS</div>
-  </div>
+  <div class="teams-more"></div>
 </div>

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -417,20 +417,7 @@ function Barchart (data, targetElement) {
     // for panning up and down the length of svg bar graph
     const offset = -((data.length - 10) * (barPadding + barHeight)) - 12;
     let expanded = false;
-    $('.teams-btn')
-      .css('display', 'initial')
-      .click(function () {
-        const graphs = $('.Team-User-Graph > svg');
-        if (!expanded) {
-          $('.teams-btn').html('Show initial teams');
-          graphs.animate({marginTop: offset}, 300);
-          expanded = true;
-        } else if (expanded) {
-          $('.teams-btn').html('Show more teams');
-          graphs.animate({marginTop: 0}, 300);
-          expanded = false;
-        }
-      });
+
   }
 
   // Define scales

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -232,7 +232,7 @@ function setupGraphs () {
     bldngGraph.parentNode.removeChild(bldngGraph);
     roadsGraph.parentNode.removeChild(roadsGraph);
   }
-  const moreBtn = $('.btn.invert-btn-grn.teams-btn');
+
   const teamLabel = $('.Team-Graph-Title .left');
   const teamUserLabel = $('.Team-User-Graph-Title .left');
   // Sets Users button to Selected, loads Users graphs, hides
@@ -242,9 +242,7 @@ function setupGraphs () {
     $('#Select-Users-Graph').addClass('Selected');
     teamLabel.text('User');
     teamUserLabel.text('User');
-    moreBtn.animate({opacity: 0}, 500, function () {
-      moreBtn.css('display', 'none');
-    });
+
     // Remove existing graphs
     removeExistingGraphs();
     // Gets main hashtag on each partner page via team.html
@@ -258,9 +256,6 @@ function setupGraphs () {
     $('#Select-Teams-Graph').addClass('Selected');
     teamLabel.text('Team');
     teamUserLabel.text('Team');
-    if (PT.subHashtags.length > 10) {
-      moreBtn.css('display', 'inline').animate({opacity: 1}, 500);
-    }
     // Remove existing graphs
     removeExistingGraphs();
     // Gets hashtag array on each partner page via team.html

--- a/app/assets/styles/_team-chart.scss
+++ b/app/assets/styles/_team-chart.scss
@@ -19,6 +19,7 @@
   padding-top: 15px;
   margin: 0 30px 0 0;
   overflow: hidden;
+  overflow-y: scroll;
   text-align: left;
   border-top: 1px solid #dddddd;
   @media screen and (max-width: 1100px) {


### PR DESCRIPTION
This PR removed the "Show More Teams" button and instead implements the css built-in "overflow" to add a scroll bar to the y-axis. 

![image](https://user-images.githubusercontent.com/1847818/53765778-f785b280-3e9e-11e9-8c30-8196e7bbcaa4.png)
