### PR TITLE
Hardcode avivauk hashtag into aviva top-level stats

### DIFF
--- a/app/_partner/aviva.md
+++ b/app/_partner/aviva.md
@@ -32,6 +32,7 @@ subhashtags:
   - avivasg
   - avivavn
   - avivaasia
+  - avivauk
 
 tm-projects:
   - id: 4983

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -331,10 +331,21 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
       const primaryRoadCount = Math.round(primaryData.road_km_add + primaryData.road_km_mod);
 
       // update the top-level stats in the hero
-      $('#stats-roadCount').html(primaryRoadCount.toLocaleString());
-      $('#stats-buildingCount').html(primaryBuildingCount.toLocaleString());
-      $('#stats-usersCount').html(primaryData.users.toLocaleString());
-      $('#stats-editsCount').html(primaryData.edits.toLocaleString());
+      // $('#stats-roadCount').html(primaryRoadCount.toLocaleString());
+      // $('#stats-buildingCount').html(primaryBuildingCount.toLocaleString());
+      // $('#stats-usersCount').html(primaryData.users.toLocaleString());
+      // $('#stats-editsCount').html(primaryData.edits.toLocaleString());
+      if (primaryHashtag == 'aviva') {
+        $('#stats-roadCount').html((primaryRoadCount + 7464).toLocaleString());
+        $('#stats-buildingCount').html((primaryBuildingCount + 245546).toLocaleString());
+        $('#stats-usersCount').html((primaryData.users + 999).toLocaleString());
+        $('#stats-editsCount').html((primaryData.edits + 348243).toLocaleString());
+      } else {
+        $('#stats-roadCount').html(primaryRoadCount.toLocaleString());
+        $('#stats-buildingCount').html(primaryBuildingCount.toLocaleString());
+        $('#stats-usersCount').html(primaryData.users.toLocaleString());
+        $('#stats-editsCount').html(primaryData.edits.toLocaleString());
+      }
 
       // For each hashtag, sum the total edits across all categories,
       // skipping over hashtags if there are no metrics (this shouldn't


### PR DESCRIPTION
@smit1678 this fix allows the stats from the #avivauk hashtag to be shown in the `partners/aviva` top-level stats. Until recently users using this hashtag were not using #aviva with it. We do not need to continuously track both stats ongoing so hardcoding the stat numbers as of today made the most sense. 