### PR TITLE
Case update for MSF primary hashtag

### DIFF
--- a/app/_partner/msf.md
+++ b/app/_partner/msf.md
@@ -15,7 +15,7 @@ hoursname:
 hourslink:
 
 
-primary-hashtag: MSFglobalmapathon2019
+primary-hashtag: msfglobalmapathon2019
 subhashtags:
   - msfamsterdam2019
   - msfbarcelona2019


### PR DESCRIPTION
Updated primary hashtag case for msf partner. This should fix page load error in http://www.missingmaps.org/partners/msf/