### PR TITLE
Merge mmcimpact and ourimpact hashtags

### DIFF
--- a/app/_partner/mmc.md
+++ b/app/_partner/mmc.md
@@ -25,7 +25,7 @@ links:
 flickr-apikey: b4f0178b524610373b2b65bda51979ba
 flickr-setId: 72157710548005558
 
-primary-hashtag: mmcimpact
+primary-hashtag: ourimpact
 subhashtags:
   - mmcmercer*
   - marshcares

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -343,6 +343,11 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
         $('#stats-buildingCount').html((primaryBuildingCount + 245546).toLocaleString());
         $('#stats-usersCount').html((primaryData.users + 999).toLocaleString());
         $('#stats-editsCount').html((primaryData.edits + 348243).toLocaleString());
+      } else if (primaryHashtag == 'ourimpact') {
+        $('#stats-roadCount').html((primaryRoadCount + 485).toLocaleString());
+        $('#stats-buildingCount').html((primaryBuildingCount + 147356).toLocaleString());
+        $('#stats-usersCount').html((primaryData.users + 1238).toLocaleString());
+        $('#stats-editsCount').html((primaryData.edits + 153575).toLocaleString());
       } else {
         $('#stats-roadCount').html(primaryRoadCount.toLocaleString());
         $('#stats-buildingCount').html(primaryBuildingCount.toLocaleString());


### PR DESCRIPTION
We hardcoded the old numbers for `#mmcimpact` to add to the newer `#ourimpact` hashtag for the MMC partner. Note that it's possible for users to be double counted using this method. 