### PR TITLE
Merge previously used DHL subhashtags

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -357,6 +357,11 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
         $('#stats-buildingCount').html((primaryBuildingCount + 79849).toLocaleString());
         $('#stats-usersCount').html((primaryData.users + 753).toLocaleString());
         $('#stats-editsCount').html((primaryData.edits + 96041).toLocaleString());
+      } else if (primaryHashtag == 'dhl') {
+        $('#stats-roadCount').html((primaryRoadCount + 27).toLocaleString());
+        $('#stats-buildingCount').html((primaryBuildingCount + 37435).toLocaleString());
+        $('#stats-usersCount').html((primaryData.users + 360).toLocaleString());
+        $('#stats-editsCount').html((primaryData.edits + 37639).toLocaleString());
       } else {
         $('#stats-roadCount').html(primaryRoadCount.toLocaleString());
         $('#stats-buildingCount').html(primaryBuildingCount.toLocaleString());


### PR DESCRIPTION
Aims to merge the contributions from a previously used DHL hashtags, using same technique that Dakota used for MMC's partner page (in this commit: https://github.com/MissingMaps/partners/commit/0f7d78d6cda6e67f3bb9c550b5cba3a581bdc632#diff-918aae927e5cab50d6f13cc596eaef1d9833e6e694f748ff2c88c181da9fe2be).