### PR TITLE
Merge previously used FactSet subhashtags

### DIFF
--- a/app/_partner/factset.md
+++ b/app/_partner/factset.md
@@ -21,7 +21,7 @@ hourslink:
 flickr-apikey: 
 flickr-setId: 
 
-primary-hashtag: factset21
+primary-hashtag: factset22
 subhashtags:
   - factset21*
   - factset22*

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -352,11 +352,11 @@ function getGroupActivityStats (hashtags, primaryHashtag) {
         $('#stats-buildingCount').html((primaryBuildingCount + 147356).toLocaleString());
         $('#stats-usersCount').html((primaryData.users + 1238).toLocaleString());
         $('#stats-editsCount').html((primaryData.edits + 153575).toLocaleString());
-      } else if (primaryHashtag == 'factset21') {
-        $('#stats-roadCount').html((primaryRoadCount + 1992).toLocaleString());
-        $('#stats-buildingCount').html((primaryBuildingCount + 79849).toLocaleString());
-        $('#stats-usersCount').html((primaryData.users + 753).toLocaleString());
-        $('#stats-editsCount').html((primaryData.edits + 96041).toLocaleString());
+      } else if (primaryHashtag == 'factset22') {
+        $('#stats-roadCount').html((primaryRoadCount + 2074).toLocaleString());
+        $('#stats-buildingCount').html((primaryBuildingCount + 110152).toLocaleString());
+        $('#stats-usersCount').html((primaryData.users + 1083).toLocaleString());
+        $('#stats-editsCount').html((primaryData.edits + 127170).toLocaleString());
       } else if (primaryHashtag == 'dhl') {
         $('#stats-roadCount').html((primaryRoadCount + 27).toLocaleString());
         $('#stats-buildingCount').html((primaryBuildingCount + 37435).toLocaleString());


### PR DESCRIPTION
Aims to merge the contributions from a previously used FactSet hashtags, using same technique that Dakota used for MMC's partner page (in this commit: 0f7d78d#diff-918aae927e5cab50d6f13cc596eaef1d9833e6e694f748ff2c88c181da9fe2be).