### PR TITLE
remove compare progress dead link

### DIFF
--- a/app/_includes/projects_aws.html
+++ b/app/_includes/projects_aws.html
@@ -23,7 +23,6 @@
             </div>
             <div>
               <a href="https://tasks.hotosm.org/projects/{{ p.id }}" class="btn btn-blue">Start Mapping</a>
-              <a href="http://www.missingmaps.org/users/" class="btn">Check your progress</a>
             </div>
           </div>
         </li>


### PR DESCRIPTION
Removed the compare progress button from this template, as it now leads to a dead page on the Missing Maps website, after the leaderboard shut down last summer.