### PR TITLE
Update teams_aws.html

### DIFF
--- a/app/_includes/teams_aws.html
+++ b/app/_includes/teams_aws.html
@@ -24,6 +24,5 @@
     </div>
   </div>
   <div class="teams-more">
-    <a href="http://www.missingmaps.org/leaderboards/#/awsmapathon" class="btn btn-blue">Compare your progress to others</a>
   </div>
 </div>


### PR DESCRIPTION
Removed dead link to compare teams to others on AWS page.